### PR TITLE
Make youtube iframe responsive

### DIFF
--- a/mftokyo2020/assets/css/youtube.css
+++ b/mftokyo2020/assets/css/youtube.css
@@ -1,0 +1,17 @@
+.youtube-video-container {
+  position: relative;
+  width: 100%;
+  margin-bottom: 20px;
+}
+.youtube-video-container:before {
+  content: "";
+  display: block;
+  padding-top: calc(9 / 16 * 100%);
+}
+.youtube-video-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+}

--- a/mftokyo2020/index.html
+++ b/mftokyo2020/index.html
@@ -18,6 +18,7 @@
 		<title>Nyanyan</title>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+		<link rel="stylesheet" href="assets/css/youtube.css" />
 		<link rel="stylesheet" href="assets/css/main.css" />
 		<noscript><link rel="stylesheet" href="assets/css/noscript.css" /></noscript>
 	</head>
@@ -60,9 +61,13 @@
 							<p>NyanTimerはスピードキューブ(ルービックキューブなどの立体パズルの速解き)のソルブタイムを測定するタイマーです。このタイマーにはインスペクションタイムの計測とラップタイムの計測という、特徴的な2つの機能があります。<br>
 							<a href="https://github.com/Nyanyan/NyanTimer" target="_blank">GitHub</a>はこちらです。</p>
 							<p>プロモーションビデオ</p>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/ierR8ZPBncU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							<div class="youtube-video-container">
+							 <iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/ierR8ZPBncU" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
 							<p>詳細紹介動画</p>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/Nj-br9DjQB4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							<div class="youtube-video-container">
+								<iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/Nj-br9DjQB4" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
 							<p>現在このタイマーは商品化を目指して開発中です。</p>
 							<span class="image main"><img src="../images/nyantimer2.jpg" alt="" /></span>
 							<p>NyanTimerの派生版として、Raspberry Piを使用した製品、NyanTimer2も製作しました</p>
@@ -76,9 +81,13 @@
 							<h3 class="major">概要</h3>
 							<p>NyanClockは革新的なルービッククロックです。このクロックにはバンプやバネはありません。そして100個を超える大量の磁石がついています。<br>
 							<p>プロモーションビデオ(v1)</p>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/tK08AjqCJuM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							<div class="youtube-video-container">
+								<iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/tK08AjqCJuM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
 							<p>プロモーションビデオ(v2)</p>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/vNmKay3xpig" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							<div class="youtube-video-container">
+								<iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/vNmKay3xpig" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
 							<span class="image main"><img src="../images/nyanclock2.jpg" alt="" /></span>
 							<span class="image main"><img src="../images/nyanclocks1.jpg" alt="" /></span>
 							<span class="image main"><img src="../images/nyanclocks2.jpg" alt="" /></span>
@@ -90,9 +99,15 @@
 							<span class="image main"><img src="../images/soltvvo.png" alt="" /></span>
 							<h3 class="major">概要</h3>
 							<p>Soltvvoは2x2x2のルービックキューブを解くロボットです。作者は2x2x2キューブ部門で平均2.93秒と日本16位の記録を持っていますが、その記録を上回るタイムで解くことを目指しています。</p>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/1UNRxuZ3I38" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/76N6BOrEjSo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-							<iframe width="560" height="315" src="https://www.youtube.com/embed/irRzZQLlo04" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							<div class="youtube-video-container">
+							 <iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/1UNRxuZ3I38" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
+							<div class="youtube-video-container">
+							 <iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/76N6BOrEjSo" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
+							<div class="youtube-video-container">
+						 	<iframe width="100%" height="100%" class="youtube-video-iframe" src="https://www.youtube.com/embed/irRzZQLlo04" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+							</div>
 							<blockquote class="twitter-tweet"><p lang="ja" dir="ltr"><a href="https://twitter.com/hashtag/2x2x2solver_nyanyan?src=hash&amp;ref_src=twsrc%5Etfw">#2x2x2solver_nyanyan</a><br>このロボットはどんなぐちゃぐちゃなルービックキューブも自動で揃えてくれます。その様子をお見せしましょう。 <a href="https://t.co/3AiXDi2tXL">pic.twitter.com/3AiXDi2tXL</a></p>&mdash; にゃにゃん (@Nyanyan_Cube) <a href="https://twitter.com/Nyanyan_Cube/status/1275809653335552002?ref_src=twsrc%5Etfw">June 24, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
 							<blockquote class="twitter-tweet"><p lang="ja" dir="ltr"><a href="https://twitter.com/hashtag/2x2x2solver_nyanyan?src=hash&amp;ref_src=twsrc%5Etfw">#2x2x2solver_nyanyan</a><br>一人で動けたね！！！偉いよ！！！ <a href="https://t.co/1kq6VBNu96">pic.twitter.com/1kq6VBNu96</a></p>&mdash; にゃにゃん (@Nyanyan_Cube) <a href="https://twitter.com/Nyanyan_Cube/status/1272031808469602305?ref_src=twsrc%5Etfw">June 14, 2020</a></blockquote> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script> 
 						</article>

--- a/mftokyo2020/index.html
+++ b/mftokyo2020/index.html
@@ -94,7 +94,7 @@
 						</article>
 
 						<!-- Soltvvo -->
-						<article id="soltvvo"">
+						<article id="soltvvo">
 							<h2 class="major">Soltvvo 2020-</h2>
 							<span class="image main"><img src="../images/soltvvo.png" alt="" /></span>
 							<h3 class="major">概要</h3>


### PR DESCRIPTION
## Solved Issues ⚠️
- Embedded youtube iframes were sticking out of the container at mobile devices
<img src="https://user-images.githubusercontent.com/23429049/94981263-b3bbc900-056b-11eb-8f57-113dc8148523.png" width="300">

- `index.html` included extra  `"`
## Changes ⛏
- Create new css file `youtube.css` to specify style iframe container and iframe itsself.
- Wrap `<iframe>` with `<div>` which is for iframe container
- Replace `height` `width` specification so that iframe spreads entire container
- Remove extra `"`


## Screenshot 📷
<img src="https://user-images.githubusercontent.com/23429049/94981352-858ab900-056c-11eb-9713-d3088c486b44.png" width="300">

